### PR TITLE
Add basic GraphQL Kafka source connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Kafka-graphql-connector
+# Kafka GraphQL Connector
+
+This project provides a simple Kafka Connect source connector that reads data from a GraphQL endpoint and publishes the results to Kafka topics.
+
+## Building
+
+Use Maven to build the connector jar:
+
+```bash
+mvn package
+```
+
+The resulting jar will be located in the `target` directory and can be deployed as a Kafka Connect plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>graphql-kafka-connector</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceConnector.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceConnector.java
@@ -1,0 +1,47 @@
+package com.example.graphqlconnector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.connector.Task;
+
+public class GraphQLSourceConnector extends SourceConnector {
+
+    private Map<String, String> config;
+
+    @Override
+    public String version() {
+        return "0.1.0";
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        this.config = props;
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return GraphQLSourceTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        List<Map<String, String>> configs = new ArrayList<>();
+        for (int i = 0; i < maxTasks; i++) {
+            configs.add(config);
+        }
+        return configs;
+    }
+
+    @Override
+    public void stop() {
+        // nothing to do
+    }
+
+    @Override
+    public ConfigDef config() {
+        return GraphQLSourceConnectorConfig.CONFIG_DEF;
+    }
+}

--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
@@ -1,0 +1,84 @@
+package com.example.graphqlconnector;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+public class GraphQLSourceConnectorConfig extends AbstractConfig {
+
+    public static final String GRAPHQL_ENDPOINT = "graphql.endpoint.url";
+    public static final String ENTITY_NAME = "entity.name";
+    public static final String RESULT_SIZE = "result.size";
+    public static final String SELECTED_COLUMNS = "selected.columns";
+    public static final String GRAPHQL_HEADERS = "graphql.headers";
+    public static final String POLLING_INTERVAL_MS = "polling.interval.ms";
+    public static final String TOPIC_PREFIX = "topic.prefix";
+    public static final String OFFSET_FIELD = "offset.field";
+    public static final String QUERY_TIMEOUT_MS = "query.timeout.ms";
+    public static final String MAX_RETRIES = "max.retries";
+    public static final String RETRY_BACKOFF_MS = "retry.backoff.ms";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(GRAPHQL_ENDPOINT, Type.STRING, Importance.HIGH, "GraphQL endpoint")
+            .define(ENTITY_NAME, Type.STRING, Importance.HIGH, "GraphQL entity name")
+            .define(RESULT_SIZE, Type.INT, 100, Importance.HIGH, "Result size per query")
+            .define(SELECTED_COLUMNS, Type.LIST, Importance.HIGH, "Selected columns")
+            .define(GRAPHQL_HEADERS, Type.MAP, Map.of(), Importance.MEDIUM, "GraphQL headers")
+            .define(POLLING_INTERVAL_MS, Type.LONG, 30000L, Importance.MEDIUM, "Polling interval ms")
+            .define(TOPIC_PREFIX, Type.STRING, "", Importance.MEDIUM, "Topic prefix")
+            .define(OFFSET_FIELD, Type.STRING, "id", Importance.MEDIUM, "Offset field")
+            .define(QUERY_TIMEOUT_MS, Type.LONG, 30000L, Importance.MEDIUM, "Query timeout ms")
+            .define(MAX_RETRIES, Type.INT, 3, Importance.MEDIUM, "Max retries")
+            .define(RETRY_BACKOFF_MS, Type.LONG, 1000L, Importance.MEDIUM, "Retry backoff ms");
+
+    public GraphQLSourceConnectorConfig(Map<String, ?> originals) {
+        super(CONFIG_DEF, originals);
+    }
+
+    public String endpoint() {
+        return getString(GRAPHQL_ENDPOINT);
+    }
+
+    public String entityName() {
+        return getString(ENTITY_NAME);
+    }
+
+    public int resultSize() {
+        return getInt(RESULT_SIZE);
+    }
+
+    public List<String> selectedColumns() {
+        return getList(SELECTED_COLUMNS);
+    }
+
+    public Map<String, String> headers() {
+        return (Map<String, String>) getMap(GRAPHQL_HEADERS);
+    }
+
+    public long pollingIntervalMs() {
+        return getLong(POLLING_INTERVAL_MS);
+    }
+
+    public String topicPrefix() {
+        return getString(TOPIC_PREFIX);
+    }
+
+    public String offsetField() {
+        return getString(OFFSET_FIELD);
+    }
+
+    public long queryTimeoutMs() {
+        return getLong(QUERY_TIMEOUT_MS);
+    }
+
+    public int maxRetries() {
+        return getInt(MAX_RETRIES);
+    }
+
+    public long retryBackoffMs() {
+        return getLong(RETRY_BACKOFF_MS);
+    }
+}
+

--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
@@ -1,0 +1,145 @@
+package com.example.graphqlconnector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTask;
+
+public class GraphQLSourceTask extends SourceTask {
+
+    private GraphQLSourceConnectorConfig config;
+    private OkHttpClient client;
+    private ObjectMapper mapper = new ObjectMapper();
+    private String nextCursor;
+
+    @Override
+    public String version() {
+        return "0.1.0";
+    }
+
+    @Override
+    public void start(Map<String, String> props) {
+        this.config = new GraphQLSourceConnectorConfig(props);
+        this.client = new OkHttpClient();
+        Map<String, Object> offset = context.offsetStorageReader().offset(Collections.singletonMap("entity", config.entityName()));
+        if (offset != null) {
+            this.nextCursor = (String) offset.getOrDefault("last_cursor", null);
+        }
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        try {
+            Thread.sleep(config.pollingIntervalMs());
+            List<SourceRecord> records = new ArrayList<>();
+            boolean hasNext = true;
+            String after = nextCursor;
+            while (hasNext) {
+                GraphQLQueryResult result = executeQuery(after);
+                for (JsonNode node : result.nodes) {
+                    Map<String, Object> sourcePartition = Collections.singletonMap("entity", config.entityName());
+                    Map<String, Object> sourceOffset = new HashMap<>();
+                    sourceOffset.put("last_cursor", result.endCursor);
+                    if (node.has(config.offsetField())) {
+                        sourceOffset.put("last_id", node.get(config.offsetField()).asText());
+                    }
+                    String topic = topic();
+                    Struct struct = buildStruct(node);
+                    Schema schema = struct.schema();
+                    SourceRecord record = new SourceRecord(sourcePartition, sourceOffset, topic, null, null, null, schema, struct);
+                    records.add(record);
+                }
+                hasNext = result.hasNextPage;
+                after = result.endCursor;
+                nextCursor = after;
+            }
+            return records;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Struct buildStruct(JsonNode node) {
+        SchemaBuilder builder = SchemaBuilder.struct();
+        for (String field : config.selectedColumns()) {
+            builder.field(field, Schema.OPTIONAL_STRING_SCHEMA);
+        }
+        Schema schema = builder.build();
+        Struct struct = new Struct(schema);
+        for (String field : config.selectedColumns()) {
+            struct.put(field, node.has(field) ? node.get(field).asText() : null);
+        }
+        return struct;
+    }
+
+    private String topic() {
+        if (config.topicPrefix().isEmpty()) {
+            return config.entityName();
+        }
+        return config.topicPrefix() + config.entityName();
+    }
+
+    private GraphQLQueryResult executeQuery(String after) throws IOException {
+        String query = buildQuery(after);
+        MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+        String body = mapper.writeValueAsString(Map.of("query", query, "variables", Map.of("first", config.resultSize(), "after", after)));
+        Request.Builder builder = new Request.Builder().url(config.endpoint()).post(RequestBody.create(body, JSON));
+        for (Map.Entry<String, String> h : config.headers().entrySet()) {
+            builder.addHeader(h.getKey(), h.getValue());
+        }
+        Request request = builder.build();
+        try (Response response = client.newCall(request).execute()) {
+            JsonNode node = mapper.readTree(response.body().string());
+            JsonNode edges = node.path("data").path(config.entityName()).path("edges");
+            List<JsonNode> nodes = new ArrayList<>();
+            String endCursor = null;
+            boolean hasNext = false;
+            for (JsonNode edge : edges) {
+                nodes.add(edge.path("node"));
+                endCursor = edge.path("cursor").asText();
+            }
+            JsonNode pageInfo = node.path("data").path(config.entityName()).path("pageInfo");
+            if (!pageInfo.isMissingNode()) {
+                hasNext = pageInfo.path("hasNextPage").asBoolean();
+                endCursor = pageInfo.path("endCursor").asText();
+            }
+            return new GraphQLQueryResult(nodes, endCursor, hasNext);
+        }
+    }
+
+    private String buildQuery(String after) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("query GetEntity($first: Int!, $after: String) {");
+        sb.append(config.entityName());
+        sb.append("(first: $first, after: $after) {");
+        sb.append("edges { node {");
+        for (String field : config.selectedColumns()) {
+            sb.append(field).append(' ');
+        }
+        sb.append("} cursor }");
+        sb.append("pageInfo { hasNextPage endCursor }");
+        sb.append("} }");
+        return sb.toString();
+    }
+
+    @Override
+    public void stop() {
+        // nothing
+    }
+
+    private record GraphQLQueryResult(List<JsonNode> nodes, String endCursor, boolean hasNextPage) {}
+}

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.connector.Connector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.connector.Connector
@@ -1,0 +1,1 @@
+com.example.graphqlconnector.GraphQLSourceConnector


### PR DESCRIPTION
## Summary
- add a Maven build with dependencies
- implement `GraphQLSourceConnector`, `GraphQLSourceTask`, and configuration class
- register connector service loader entry
- document build instructions

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687b900eec0c8321a4c27c9dc96ce229