### PR TITLE
Fix optional cursor variable in GraphQL query

### DIFF
--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
@@ -99,7 +99,12 @@ public class GraphQLSourceTask extends SourceTask {
     private GraphQLQueryResult executeQuery(String after) throws IOException {
         String query = buildQuery(after);
         MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-        String body = mapper.writeValueAsString(Map.of("query", query, "variables", Map.of("first", config.resultSize(), "after", after)));
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("first", config.resultSize());
+        if (after != null) {
+            variables.put("after", after);
+        }
+        String body = mapper.writeValueAsString(Map.of("query", query, "variables", variables));
         Request.Builder builder = new Request.Builder().url(config.endpoint()).post(RequestBody.create(body, JSON));
         for (Map.Entry<String, String> h : config.headers().entrySet()) {
             builder.addHeader(h.getKey(), h.getValue());
@@ -129,9 +134,17 @@ public class GraphQLSourceTask extends SourceTask {
 
     private String buildQuery(String after) {
         StringBuilder sb = new StringBuilder();
-        sb.append("query GetEntity($first: Int!, $after: String) {");
+        sb.append("query GetEntity($first: Int!");
+        if (after != null) {
+            sb.append(", $after: String");
+        }
+        sb.append(") {");
         sb.append(config.entityName());
-        sb.append("(first: $first, after: $after) {");
+        sb.append("(first: $first");
+        if (after != null) {
+            sb.append(", after: $after");
+        }
+        sb.append(") {");
         sb.append("edges { node {");
         for (String field : config.selectedColumns()) {
             sb.append(field).append(' ');


### PR DESCRIPTION
## Summary
- handle null `after` cursor when building GraphQL variables
- only include the `after` parameter in the query string when provided

## Testing
- `mvn -q -e package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b940bddec832189d57af49bbf151e