### PR TITLE
Fix headers casting in GraphQLSourceConnectorConfig

### DIFF
--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
@@ -56,7 +56,7 @@ public class GraphQLSourceConnectorConfig extends AbstractConfig {
 
     public Map<String, String> headers() {
         Map<String, Object> raw = getMap(GRAPHQL_HEADERS);
-        Map<String, String> headers = new java.util.HashMap<>();
+        Map<String, String> headers = new HashMap<>();
         for (Map.Entry<String, Object> e : raw.entrySet()) {
             if (e.getValue() != null) {
                 headers.put(e.getKey(), e.getValue().toString());

--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceConnectorConfig.java
@@ -55,7 +55,14 @@ public class GraphQLSourceConnectorConfig extends AbstractConfig {
     }
 
     public Map<String, String> headers() {
-        return (Map<String, String>) getMap(GRAPHQL_HEADERS);
+        Map<String, Object> raw = getMap(GRAPHQL_HEADERS);
+        Map<String, String> headers = new java.util.HashMap<>();
+        for (Map.Entry<String, Object> e : raw.entrySet()) {
+            if (e.getValue() != null) {
+                headers.put(e.getKey(), e.getValue().toString());
+            }
+        }
+        return headers;
     }
 
     public long pollingIntervalMs() {


### PR DESCRIPTION
## Summary
- fix unsafe cast when returning headers map

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_b_687b966be5c88321b6ac90119340b104