### PR TITLE
Fix polling loop delay

### DIFF
--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
@@ -69,10 +69,11 @@ public class GraphQLSourceTask extends SourceTask {
                 after = result.endCursor;
                 nextCursor = after;
             }
-            Thread.sleep(config.pollingIntervalMs());
             return records;
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            Thread.sleep(config.pollingIntervalMs());
         }
     }
 

--- a/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
+++ b/src/main/java/com/example/graphqlconnector/GraphQLSourceTask.java
@@ -44,7 +44,6 @@ public class GraphQLSourceTask extends SourceTask {
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
         try {
-            Thread.sleep(config.pollingIntervalMs());
             List<SourceRecord> records = new ArrayList<>();
             boolean hasNext = true;
             String after = nextCursor;
@@ -70,6 +69,7 @@ public class GraphQLSourceTask extends SourceTask {
                 after = result.endCursor;
                 nextCursor = after;
             }
+            Thread.sleep(config.pollingIntervalMs());
             return records;
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
- move Thread.sleep in `GraphQLSourceTask` to the end of the poll method

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687b985313f083218c44cf2c135fe5e1